### PR TITLE
Added --force_polling argument to command in docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ version: '3'
 services:
   techblog:
     image: jekyll/jekyll:3.4.3
-    command: jekyll serve
+    command: jekyll serve --force_polling
     ports:
       - "4000:4000"
     volumes:


### PR DESCRIPTION
When using the Jekyll docker container, on Windows 10, and files are changed, auto-generation is not working. Seems that the issue is related to NTFS, de file change events are not fetched by Jekyll and no auto-generation is triggered. By adding an additional argument to the docker-compose.yml command we can force Jekyll into polling the file system, so that it picks up the changes and generates new output files.